### PR TITLE
Add manager + refactor Emitter

### DIFF
--- a/metrics/graphite/graphite_test.go
+++ b/metrics/graphite/graphite_test.go
@@ -5,21 +5,23 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/teststat"
 )
 
 func TestHistogramQuantiles(t *testing.T) {
 	prefix := "prefix"
-	e := NewEmitter("", "", prefix, nil)
+	e := NewEmitter("", "", prefix, time.Second, log.NewNopLogger())
 	var (
 		name      = "test_histogram_quantiles"
 		quantiles = []int{50, 90, 95, 99}
 	)
 	h, err := e.NewHistogram(name, 0, 100, 3, quantiles...)
 	if err != nil {
-		t.Fatalf("unable to create test histogram: ", err)
+		t.Fatalf("unable to create test histogram: %v", err)
 	}
 	h = h.With(metrics.Field{Key: "ignored", Value: "field"})
 	const seed, mean, stdev int64 = 424242, 50, 10
@@ -36,7 +38,7 @@ func TestCounter(t *testing.T) {
 		prefix = "prefix"
 		name   = "m"
 		value  = 123
-		e      = NewEmitter("", "", prefix, nil)
+		e      = NewEmitter("", "", prefix, time.Second, log.NewNopLogger())
 		b      bytes.Buffer
 	)
 	e.NewCounter(name).With(metrics.Field{Key: "ignored", Value: "field"}).Add(uint64(value))
@@ -54,7 +56,7 @@ func TestGauge(t *testing.T) {
 		name   = "xyz"
 		value  = 54321
 		delta  = 12345
-		e      = NewEmitter("", "", prefix, nil)
+		e      = NewEmitter("", "", prefix, time.Second, log.NewNopLogger())
 		b      bytes.Buffer
 		g      = e.NewGauge(name).With(metrics.Field{Key: "ignored", Value: "field"})
 	)

--- a/metrics/graphite/graphite_test.go
+++ b/metrics/graphite/graphite_test.go
@@ -72,3 +72,9 @@ func TestGauge(t *testing.T) {
 		t.Errorf("gauge %s want\n%s, have\n%s", name, want, payload)
 	}
 }
+
+func TestEmitterStops(t *testing.T) {
+	e := NewEmitter("foo", "bar", "baz", time.Second, log.NewNopLogger())
+	time.Sleep(100 * time.Millisecond)
+	e.Stop()
+}

--- a/metrics/graphite/manager.go
+++ b/metrics/graphite/manager.go
@@ -1,0 +1,105 @@
+package graphite
+
+import (
+	"net"
+	"time"
+
+	"github.com/go-kit/kit/log"
+)
+
+// Dialer dials a network and address. net.Dial is a good default Dialer.
+type Dialer func(network, address string) (net.Conn, error)
+
+// time.After is a good default afterFunc.
+type afterFunc func(time.Duration) <-chan time.Time
+
+// manager manages a net.Conn. Clients should take the conn when they want to
+// use it, and put back whatever error they receive from an e.g. Write. When a
+// non-nil error is put, the conn is invalidated and a new conn is established.
+// Connection failures are retried after an exponential backoff.
+type manager struct {
+	dial    Dialer
+	network string
+	address string
+	after   afterFunc
+	logger  log.Logger
+
+	takec chan net.Conn
+	putc  chan error
+}
+
+func newManager(d Dialer, network, address string, after afterFunc, logger log.Logger) *manager {
+	m := &manager{
+		dial:    d,
+		network: network,
+		address: address,
+		after:   after,
+		logger:  logger,
+
+		takec: make(chan net.Conn),
+		putc:  make(chan error),
+	}
+	go m.loop()
+	return m
+}
+
+func (m *manager) take() net.Conn {
+	return <-m.takec
+}
+
+func (m *manager) put(err error) {
+	m.putc <- err
+}
+
+func (m *manager) loop() {
+	var (
+		conn       = dial(m.dial, m.network, m.address, m.logger) // may block slightly
+		connc      = make(chan net.Conn)
+		reconnectc <-chan time.Time // initially nil
+		backoff    = time.Second
+	)
+
+	for {
+		select {
+		case <-reconnectc:
+			reconnectc = nil
+			go func() { connc <- dial(m.dial, m.network, m.address, m.logger) }()
+
+		case conn = <-connc:
+			if conn == nil {
+				backoff = exponential(backoff)
+				reconnectc = m.after(backoff)
+			} else {
+				backoff = time.Second
+				reconnectc = nil
+			}
+
+		case m.takec <- conn:
+			// might be nil
+
+		case err := <-m.putc:
+			if err != nil && conn != nil {
+				m.logger.Log("err", err)
+				conn = nil                            // connection is bad
+				reconnectc = m.after(time.Nanosecond) // trigger immediately
+			}
+		}
+	}
+}
+
+func dial(d Dialer, network, address string, logger log.Logger) net.Conn {
+	conn, err := d(network, address)
+	if err != nil {
+		logger.Log("err", err)
+		conn = nil
+	}
+	return conn
+}
+
+func exponential(d time.Duration) time.Duration {
+	d *= 2
+	if d > time.Minute {
+		d = time.Minute
+	}
+	return d
+}

--- a/metrics/graphite/manager_test.go
+++ b/metrics/graphite/manager_test.go
@@ -1,0 +1,126 @@
+package graphite
+
+import (
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+)
+
+func TestManager(t *testing.T) {
+	var (
+		tickc    = make(chan time.Time)
+		after    = func(time.Duration) <-chan time.Time { return tickc }
+		dialconn = &mockConn{}
+		dialerr  = error(nil)
+		dialer   = func(string, string) (net.Conn, error) { return dialconn, dialerr }
+		mgr      = newManager(dialer, "netw", "addr", after, log.NewNopLogger())
+	)
+
+	// First conn should be fine.
+	conn := mgr.take()
+	if conn == nil {
+		t.Fatal("nil conn")
+	}
+
+	// Write and check it went thru.
+	if _, err := conn.Write([]byte{1, 2, 3}); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := uint64(3), atomic.LoadUint64(&dialconn.wr); want != have {
+		t.Errorf("want %d, have %d", want, have)
+	}
+
+	// Put an error to kill the conn.
+	mgr.put(errors.New("should kill the connection"))
+
+	// First takes should fail.
+	for i := 0; i < 10; i++ {
+		if conn = mgr.take(); conn != nil {
+			t.Fatalf("want nil conn, got real conn")
+		}
+	}
+
+	// Trigger the reconnect.
+	tickc <- time.Now()
+
+	// The dial should eventually succeed and yield a good conn.
+	if !within(100*time.Millisecond, func() bool {
+		conn = mgr.take()
+		return conn != nil
+	}) {
+		t.Fatal("conn remained nil")
+	}
+
+	// Write and check it went thru.
+	if _, err := conn.Write([]byte{4, 5}); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := uint64(5), atomic.LoadUint64(&dialconn.wr); want != have {
+		t.Errorf("want %d, have %d", want, have)
+	}
+
+	// Dial starts failing.
+	dialconn, dialerr = nil, errors.New("oh noes")
+	mgr.put(errors.New("trigger that reconnect y'all"))
+	if conn = mgr.take(); conn != nil {
+		t.Fatalf("want nil conn, got real conn")
+	}
+
+	// As many reconnects as they want.
+	go func() {
+		done := time.After(100 * time.Millisecond)
+		for {
+			select {
+			case tickc <- time.Now():
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	// The dial should never succeed.
+	if within(100*time.Millisecond, func() bool {
+		conn = mgr.take()
+		return conn != nil
+	}) {
+		t.Fatal("eventually got a good conn, despite failing dialer")
+	}
+}
+
+type mockConn struct {
+	rd, wr uint64
+}
+
+func (c *mockConn) Read(b []byte) (n int, err error) {
+	atomic.AddUint64(&c.rd, uint64(len(b)))
+	return len(b), nil
+}
+
+func (c *mockConn) Write(b []byte) (n int, err error) {
+	atomic.AddUint64(&c.wr, uint64(len(b)))
+	return len(b), nil
+}
+
+func (c *mockConn) Close() error                       { return nil }
+func (c *mockConn) LocalAddr() net.Addr                { return nil }
+func (c *mockConn) RemoteAddr() net.Addr               { return nil }
+func (c *mockConn) SetDeadline(t time.Time) error      { return nil }
+func (c *mockConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *mockConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func within(d time.Duration, f func() bool) bool {
+	deadline := time.Now().Add(d)
+	for {
+		if time.Now().After(deadline) {
+			return false
+		}
+		if f() {
+			return true
+		}
+		time.Sleep(d / 10)
+	}
+}


### PR DESCRIPTION
Sorry, I mixed code changes with comment changes :( :(

The manager is more or less a direct copy of the code I gisted, only real change is we make a connection synchronously with construction, so that may block; this was necessary for deterministic testing. I removed Start; Emitter automatically starts on construction. And it's now just a programmer error to call Stop more than once; easier this way.

Major change is the Emitter main loop. It calls Flush every flushInterval. Flush tries to grab a conn from the manager. If the conn is nil, then oh well, we just don't flush this time. If the conn is good, we flush using the conn as the io.Writer, and make sure to put the resulting error back to the manager, so it can reconnect if it needs to.

Everything make sense? Did I overlook something?
